### PR TITLE
DATA-1383: Adding --no-steps-limit option

### DIFF
--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -63,7 +63,9 @@ only join clusters whose fleets use the same set of instances or a subset;
 there is no concept of "better" instances.
 
 mrjob's pooling won't add more than 1000 steps to a cluster, as the
-EMR API won't show more than this many steps. (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
+EMR API won't show more than this many steps. This behavior can be overridden
+using the :mrjob-opt:`no_steps_limit` in versions that support unlimited steps.
+(For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
 there is a stricter limit of 256 steps).
 
 :py:mod:`mrjob` also uses an S3-based

--- a/mrjob/__init__.py
+++ b/mrjob/__init__.py
@@ -135,4 +135,4 @@ __credits__ = [
     'drulludanni <drulludanni5@gmail.com>',
 ]
 
-__version__ = '0.6.7+affirm.1.0.14'
+__version__ = '0.6.7+affirm.1.1.0'

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -73,6 +73,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         'master_instance_type',
         'max_mins_idle',
         'max_hours_idle',
+        'no_steps_limit',
         'num_core_instances',
         'num_task_instances',
         'region',
@@ -131,6 +132,7 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
             dict(
                 cloud_part_size_mb=100,  # 100 MB
                 max_mins_idle=_DEFAULT_MAX_MINS_IDLE,
+                no_steps_limit=False,
                 # don't use a list because it makes it hard to read option
                 # values when running in verbose mode. See #1284
                 ssh_bind_ports=xrange(40001, 40841),

--- a/mrjob/emr.py
+++ b/mrjob/emr.py
@@ -2627,32 +2627,43 @@ class EMRJobRunner(HadoopInTheCloudJobRunner, LogInterpretationMixin):
 
         :return: -1 on failure or num_steps_in_cluster on success
         """
-        steps = list(_boto3_paginate(
-            'Steps',
-            emr_client, 'list_steps', ClusterId=cluster['Id']))
-
         if self._opts['release_label']:
             max_steps = _4_X_MAX_STEPS
+            allows_unlimited_steps = True
         else:
             image_version = cluster.get('RunningAmiVersion', '')
             max_steps = map_version(image_version, _IMAGE_VERSION_TO_MAX_STEPS)
+            allows_unlimited_steps = False
 
-        # don't add more steps than EMR will allow/display through the API
-        if len(steps) + num_steps > max_steps:
-            log.debug('    no room for our steps')
-            return -1
+        if self._opts['no_steps_limit'] and allows_unlimited_steps:
+           steps = list(_boto3_paginate(
+               'Steps',
+               emr_client, 'list_steps',
+               ClusterId=cluster['Id'], StepStates=['RUNNING', 'PENDING']))
+           if steps:
+               log.debug('    unfinished steps')
+               return -1
+        else:
+            steps = list(_boto3_paginate(
+                'Steps',
+                emr_client, 'list_steps', ClusterId=cluster['Id']))
 
-        # in rare cases, cluster can be WAITING *and* have incomplete
-        # steps. We could just check for PENDING steps, but we're
-        # trying to be defensive about EMR adding a new step state.
-        # Not entirely sure what to make of CANCEL_PENDING
-        for step in steps:
-            if (step['Status']['State'] not in (
-                    'CANCELLED', 'INTERRUPTED') and
-                    not step['Status'].get('Timeline', {}).get(
-                        'EndDateTime')):
-                log.debug('    unfinished steps')
+            # don't add more steps than EMR will allow/display through the API
+            if len(steps) + num_steps > max_steps:
+                log.debug('    no room for our steps')
                 return -1
+
+            # in rare cases, cluster can be WAITING *and* have incomplete
+            # steps. We could just check for PENDING steps, but we're
+            # trying to be defensive about EMR adding a new step state.
+            # Not entirely sure what to make of CANCEL_PENDING
+            for step in steps:
+                if (step['Status']['State'] not in (
+                        'CANCELLED', 'INTERRUPTED') and
+                        not step['Status'].get('Timeline', {}).get(
+                            'EndDateTime')):
+                    log.debug('    unfinished steps')
+                    return -1
 
         log.debug('    OK - valid cluster state')
         return len(steps)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1050,6 +1050,18 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
+    no_steps_limit=dict(
+        switches=[
+            (['--no-steps-limit'], dict(
+                action='store_true',
+                help=('It is okay for the earliest steps to stop showing up '
+                      'in the console/API. Feel free to continue adding new '
+                      'steps (this also helps with ListSteps throttling). '
+                      'Ignored for older EMR versions that have a hard limit '
+                      'on the number of steps'),
+            )),
+        ]
+    ),
     num_core_instances=dict(
         cloud_role='launch',
         switches=[

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1879,7 +1879,7 @@ class MasterNodeSetupScriptTestCase(MockBoto3TestCase):
         self.assertIsNotNone(runner._master_node_setup_script_path)
 
         with open(runner._master_node_setup_script_path, 'rb') as f:
-            contents = f.read()
+            contents = f.read().decode("utf-8")
 
         expected_contents = '  COW=MOO\n  CAT=MEOW\n' \
                             '  echo "$COW"\n  echo "$CAT"\n'


### PR DESCRIPTION
https://jira.team.affirm.com/browse/DATA-1383

Currently MRJob scans through the entire list of steps in an existing cluster to determine if the cluster is available to submit new jobs. We have been frequently hitting throttling limits for the ListSteps API lately, preventing MRJob from being able to determine cluster availability. So it continues to wait and poll clusters, thereby holding up jobs until the cluster(s) get torn down due to idle time.

Mitigating this issue by adding a --no-steps-limit option that has MRJob run a filtered query for PENDING/RUNNING steps and not scan the entire list of steps.

Testing:
* Tests added
* All tests pass