### PR TITLE
make unit tests pass on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   fast_finish: true
 install:
   - "pip install ."
+  - "pip install -e .[google]"
   - "pip install ujson warcio"
   - "pip install rapidjson || true"
 # command to run tests

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ try:
             'boto3>=1.4.6',
             'botocore>=1.6.0',
             'PyYAML>=3.08',
+            'requests',  # required for Affirm fork
         ],
         'provides': ['mrjob'],
         'test_suite': 'tests',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,13 @@ try:
         setuptools_kwargs['extras_require']['rapidjson'] = ['rapidjson']
         setuptools_kwargs['tests_require'].append('rapidjson')
 
+    # don't try to install latest PyYAML on Python 3.4
+    if sys.version_info[:2] == (3, 4):
+        setuptools_kwargs['install_requires'] = [
+            ir + ',<5.2' if ir.startswith('PyYAML') else ir
+            for ir in setuptools_kwargs['install_requires']
+        ]
+
 except ImportError:
     from distutils.core import setup
     setuptools_kwargs = {}


### PR DESCRIPTION
Small tweaks to library installs in order to make the unit tests for `v0.6.7-affirm` pass on Travis CI.