### PR TITLE
Changes to change cluster locking mechanism and ease throttling

### DIFF
--- a/docs/guides/pooling.rst
+++ b/docs/guides/pooling.rst
@@ -63,8 +63,7 @@ only join clusters whose fleets use the same set of instances or a subset;
 there is no concept of "better" instances.
 
 mrjob's pooling won't add more than 1000 steps to a cluster, as the
-EMR API won't show more than this many steps. This behavior can be overridden
-using the :mrjob-opt:`no_steps_limit` in versions that support unlimited steps.
+EMR API won't show more than this many steps.
 (For `very old AMIs <http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/AddingStepstoaJobFlow.html>`__
 there is a stricter limit of 256 steps).
 

--- a/mrjob/cloud.py
+++ b/mrjob/cloud.py
@@ -73,7 +73,6 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
         'master_instance_type',
         'max_mins_idle',
         'max_hours_idle',
-        'no_steps_limit',
         'num_core_instances',
         'num_task_instances',
         'region',
@@ -132,7 +131,6 @@ class HadoopInTheCloudJobRunner(MRJobBinRunner):
             dict(
                 cloud_part_size_mb=100,  # 100 MB
                 max_mins_idle=_DEFAULT_MAX_MINS_IDLE,
-                no_steps_limit=False,
                 # don't use a list because it makes it hard to read option
                 # values when running in verbose mode. See #1284
                 ssh_bind_ports=xrange(40001, 40841),

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -1050,18 +1050,6 @@ _RUNNER_OPTS = dict(
             )),
         ],
     ),
-    no_steps_limit=dict(
-        switches=[
-            (['--no-steps-limit'], dict(
-                action='store_true',
-                help=('It is okay for the earliest steps to stop showing up '
-                      'in the console/API. Feel free to continue adding new '
-                      'steps (this also helps with ListSteps throttling). '
-                      'Ignored for older EMR versions that have a hard limit '
-                      'on the number of steps'),
-            )),
-        ]
-    ),
     num_core_instances=dict(
         cloud_role='launch',
         switches=[

--- a/tests/test_emr_pooling.py
+++ b/tests/test_emr_pooling.py
@@ -1536,25 +1536,6 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '-r', 'emr', '-v', '--pool-clusters'],
             job_class=MRTwoStepJob)
 
-    def test_available_no_steps_limit(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster()
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 999 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED'))
-        ]
-
-        # adding a two-step job should be fine
-        self.assertJoins(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters', '--no-steps-limit'],
-            job_class=MRTwoStepJob)
-
     def test_join_almost_full_cluster(self):
         dummy_runner, cluster_id = self.make_pooled_cluster()
 
@@ -1576,117 +1557,6 @@ class PoolMatchingTestCase(MockBoto3TestCase):
             '-r', 'emr', '-v', '--pool-clusters'],
             job_class=MRWordCount)
 
-    def test_dont_join_full_cluster_256_step_limit(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster(
-            image_version='2.4.7')
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 255 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED',
-                    Timeline=dict(
-                        EndDateTime='definitely not none')))
-        ]
-
-        # a two-step job shouldn't fit
-        self.assertDoesNotJoin(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters',
-            '--image-version', '2.4.7'],
-            job_class=MRTwoStepJob)
-
-    def test_dont_join_full_cluster_256_no_steps_limit(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster(
-            image_version='2.4.7')
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 255 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED'))
-        ]
-
-        # adding a two-step job should be fine
-        self.assertDoesNotJoin(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters',
-            '--image-version', '2.4.7',
-            '--no-steps-limit'],
-            job_class=MRTwoStepJob)
-
-    def test_join_almost_full_2_x_ami_cluster(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster(
-            image_version='2.4.7')
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 255 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED',
-                    Timeline=dict(
-                        EndDateTime='definitely not none')))
-        ]
-
-        # a one-step job should fit
-        self.assertJoins(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters', '--image-version', '2.4.7'],
-            job_class=MRWordCount)
-
-    def test_no_space_for_master_node_setup(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster()
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 999 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED',
-                    Timeline=dict(
-                        EndDateTime='definitely not none')))
-        ]
-
-        # --libjars makes this a two-step job, which won't fit
-        self.assertDoesNotJoin(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters',
-            '--libjars', 's3:///poohs-house/HUNNY.jar'],
-            job_class=MRWordCount)
-
-    def test_bearly_space_for_master_node_setup(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster()
-
-        # fill the cluster
-        self.mock_emr_clusters[cluster_id]['_Steps'] = 998 * [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Id='s-FAKE',
-                Name='dummy',
-                Status=dict(
-                    State='COMPLETED',
-                    Timeline=dict(
-                        EndDateTime='definitely not none')))
-        ]
-
-        # now there's space for two steps
-        self.assertJoins(cluster_id, [
-            '-r', 'emr', '-v', '--pool-clusters',
-            '--libjars', 's3://poohs-house/HUNNY.jar'],
-            job_class=MRWordCount)
-
     def test_dont_join_idle_with_pending_steps(self):
         dummy_runner, cluster_id = self.make_pooled_cluster()
 
@@ -1702,39 +1572,6 @@ class PoolMatchingTestCase(MockBoto3TestCase):
 
         self.assertDoesNotJoin(cluster_id,
                                ['-r', 'emr', '--pool-clusters'])
-
-    def test_dont_join_idle_with_pending_steps_no_steps_limit(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster()
-
-        cluster = self.mock_emr_clusters[cluster_id]
-
-        cluster['_Steps'] = [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Name='dummy',
-                Status=dict(State='PENDING'))]
-        cluster['_DelayProgressSimulation'] = 100  # keep step PENDING
-
-        self.assertDoesNotJoin(cluster_id,
-                               ['-r', 'emr', '--pool-clusters',
-                                '--no-steps-limit'])
-
-    def test_dont_join_idle_with_running_steps_no_steps_limit(self):
-        dummy_runner, cluster_id = self.make_pooled_cluster()
-
-        cluster = self.mock_emr_clusters[cluster_id]
-
-        cluster['_Steps'] = [
-            dict(
-                ActionOnFailure='CANCEL_AND_WAIT',
-                Config=dict(Args=[]),
-                Name='dummy',
-                Status=dict(State='RUNNING'))]
-
-        self.assertDoesNotJoin(cluster_id,
-                               ['-r', 'emr', '--pool-clusters',
-                                '--no-steps-limit'])
 
     def test_do_join_idle_with_cancelled_steps(self):
         dummy_runner, cluster_id = self.make_pooled_cluster()

--- a/tests/tools/emr/test_terminate_idle_clusters.py
+++ b/tests/tools/emr/test_terminate_idle_clusters.py
@@ -78,6 +78,7 @@ class ClusterTerminationTestCase(MockBoto3TestCase):
                 timeline['EndDateTime'] = ended
 
             return dict(
+                Id='s-DEFAULT_STEP',
                 Config=dict(
                     ActionOnFailure=action_on_failure,
                     Args=args,


### PR DESCRIPTION
Just opening this pull request for Dave Marin to see what I was trying to do to reduce throttling.

A WIP review with the following eventual goals:
(1) Change the cluster locking logic to use ID of latest step instead of step count as the lock string/file
(2) Remove full scans of cluster steps to determine cluster availability, thus easing throttling
(2) Remove support for very old versions of EMR clusters (that are limited to 256 steps total)